### PR TITLE
SAI editor: fixed window owner error on linux

### DIFF
--- a/WoWDatabaseEditorCore.Avalonia/Managers/WindowManager.cs
+++ b/WoWDatabaseEditorCore.Avalonia/Managers/WindowManager.cs
@@ -332,13 +332,29 @@ namespace WoWDatabaseEditorCore.Avalonia.Managers
                     {
                         WeakReference<IInputElement>? focusedElement = null;
                         var parentWindow = GetFocusedWindow();
+
+                        var lifetime = Application.Current!.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
+                        if (lifetime != null && !lifetime.Windows.Contains(parentWindow))
+                        {
+                            parentWindow = mainWindowHolder.RootWindow;
+                        }
+
                         if (TopLevel.GetTopLevel(parentWindow)?.FocusManager?.GetFocusedElement() is
                             { } focusedElement_)
                         {
                             focusedElement = new WeakReference<IInputElement>(focusedElement_);
                         }
 
-                        var result = await view.ShowDialog<bool>(parentWindow);
+                        bool result;
+                        try
+                        {
+                            result = await view.ShowDialog<bool>(parentWindow);
+                        }
+                        catch (InvalidOperationException ex) when (ex.Message.Contains("closed owner"))
+                        {
+                            parentWindow = mainWindowHolder.RootWindow;
+                            result = await view.ShowDialog<bool>(parentWindow);
+                        }
 
                         Dispatcher.UIThread.Post(() =>
                         {


### PR DESCRIPTION
fixes the closed owner error on linux when opening a followup window in the SAI editor. 

Needs verification from Windows user as i dont own any

Fixes #260 